### PR TITLE
fix for undefined service fee in the tokenize response

### DIFF
--- a/src/components/pay-theory-hosted-field-transactional/index.js
+++ b/src/components/pay-theory-hosted-field-transactional/index.js
@@ -143,13 +143,14 @@ class PayTheoryHostedFieldTransactional extends PayTheoryHostedField {
     if (oldIdempotency.idempotency !== _idempotency.idempotency) {
       this.idempotency = _idempotency
       if (this.reset) this.reset()
+      const fee = _idempotency.fee_mode === common.SERVICE_FEE ? _idempotency.fee : 0
       const cbToken = {
         "first_six": _idempotency.first_six,
         "last_four": _idempotency.last_four,
         "brand": _idempotency.brand,
         "receipt_number": _idempotency.idempotency,
         "amount": _idempotency.amount,
-        "service_fee": _idempotency.service_fee
+        "service_fee": fee
       }
       this.idempotencyCB(cbToken)
     }


### PR DESCRIPTION
parsed the token response to pass the fee properly to the token response. 