### PR TITLE
feat(checkout-token-migration): checkoutContext SDK init — checkout-portal MVP rollout

### DIFF
--- a/src/common/network.ts
+++ b/src/common/network.ts
@@ -8,7 +8,7 @@ import {
   getHostedFieldsEndpoint,
   getTransactionEndpoint,
 } from './network.local';
-import { BillingInfo } from './pay_theory_types';
+import { BillingInfo, CheckoutContextQuery } from './pay_theory_types';
 import { withExponentialBackoff } from './retry-utils';
 
 interface PtToken {
@@ -36,6 +36,27 @@ export const getData = async (
   return await response.json();
 };
 
+const getCheckoutData = async (
+  url: string,
+  sessionKey?: string,
+): Promise<PtToken | object> => {
+  const headers: Record<string, string> = {};
+  if (sessionKey) {
+    headers['x-session-key'] = sessionKey;
+  }
+
+  const options: RequestInit = {
+    method: 'GET',
+    mode: 'cors',
+    cache: 'no-cache',
+    headers,
+  };
+
+  /* global fetch */
+  const response = await fetch(url, options);
+  return await response.json();
+};
+
 // Legacy static variables (kept for compatibility)
 export const PARTNER = process.env.ENV;
 export const STAGE = process.env.STAGE;
@@ -53,6 +74,45 @@ export const fetchPtToken = async (
 ): Promise<PtToken | false> => {
   const result = await withExponentialBackoff(
     () => getData(transactionEndpoint, apiKey, sessionKey),
+    token => !(token as PtToken)['pt-token'],
+    {
+      maxAttempts: 5,
+      initialDelay: 100,
+      maxDelay: 2000,
+      jitter: true,
+    },
+  );
+
+  return (result as PtToken) || false;
+};
+
+const buildCheckoutTokenUrl = (checkoutContext: CheckoutContextQuery): string => {
+  const checkoutTokenEndpoint = `${transactionEndpoint}checkout-token`;
+
+  const provided: Array<[string, string]> = [];
+  if (checkoutContext.invoiceId) provided.push(['invoice_id', checkoutContext.invoiceId]);
+  if (checkoutContext.linkId) provided.push(['link_id', checkoutContext.linkId]);
+  if (checkoutContext.recurringHash)
+    provided.push(['recurring_hash', checkoutContext.recurringHash]);
+  if (checkoutContext.sessionId) provided.push(['session_id', checkoutContext.sessionId]);
+
+  if (provided.length !== 1) {
+    throw new Error('Must provide exactly one of invoiceId, linkId, recurringHash, or sessionId');
+  }
+
+  const [key, value] = provided[0];
+  return `${checkoutTokenEndpoint}?${key}=${encodeURIComponent(value)}`;
+};
+
+export const fetchCheckoutPtToken = async (
+  checkoutContext: CheckoutContextQuery,
+  sessionKey: string,
+): Promise<PtToken | false> => {
+  const url = buildCheckoutTokenUrl(checkoutContext);
+  const shouldSendSessionKey = !checkoutContext.sessionId;
+
+  const result = await withExponentialBackoff(
+    () => getCheckoutData(url, shouldSendSessionKey ? sessionKey : undefined),
     token => !(token as PtToken)['pt-token'],
     {
       maxAttempts: 5,

--- a/src/common/pay_theory_types.ts
+++ b/src/common/pay_theory_types.ts
@@ -170,8 +170,13 @@ export interface TransactProps {
   expandedResponse?: boolean;
 }
 
-export interface PayTheoryPaymentFieldsInput {
-  apiKey: string;
+export type CheckoutContextQuery =
+  | { invoiceId: string; linkId?: never; recurringHash?: never; sessionId?: never }
+  | { linkId: string; invoiceId?: never; recurringHash?: never; sessionId?: never }
+  | { recurringHash: string; invoiceId?: never; linkId?: never; sessionId?: never }
+  | { sessionId: string; invoiceId?: never; linkId?: never; recurringHash?: never };
+
+export type PayTheoryPaymentFieldsInput = {
   styles?: StyleObject;
   metadata?: Record<string | number, string | number | boolean>;
   placeholders?: PlaceholderObject;
@@ -180,7 +185,16 @@ export interface PayTheoryPaymentFieldsInput {
   feeMode?: typeof MERCHANT_FEE | typeof SERVICE_FEE;
   amount?: number;
   country?: string;
-}
+} & (
+  | {
+      apiKey: string;
+      checkoutContext?: never;
+    }
+  | {
+      apiKey?: never;
+      checkoutContext: CheckoutContextQuery;
+    }
+);
 
 export enum AcceptedPaymentMethods {
   ALL = 'ALL',

--- a/src/components/pay-theory-hosted-field-transactional/index.ts
+++ b/src/components/pay-theory-hosted-field-transactional/index.ts
@@ -33,6 +33,7 @@ import {
 } from '../../common/message';
 import {
   BillingInfo,
+  CheckoutContextQuery,
   ErrorResponse,
   ErrorType,
   FieldState,
@@ -85,6 +86,7 @@ class PayTheoryHostedFieldTransactional extends PayTheoryHostedField {
   // Used to fetch the pt-token attribute to initialize the hosted field
   protected _apiKey: string | undefined;
   protected _challengeOptions: object | undefined;
+  protected _checkoutContext: CheckoutContextQuery | undefined;
   protected _session: string | undefined;
 
   // Used to track the metadata that is passed in for a session
@@ -174,7 +176,9 @@ class PayTheoryHostedFieldTransactional extends PayTheoryHostedField {
     type: `pt-static:connection_token` | `pt-static:reset_host`,
   ): Promise<ErrorResponse | ReadyResponse> {
     try {
-      const ptToken = await common.fetchPtToken(this._apiKey ?? '', this._session);
+      const ptToken = this._checkoutContext
+        ? await common.fetchCheckoutPtToken(this._checkoutContext, this._session)
+        : await common.fetchPtToken(this._apiKey ?? '', this._session);
       if (ptToken) {
         this._challengeOptions = ptToken.challengeOptions;
         const transactingIFrame = document.getElementById(this._transactingIFrameId) as
@@ -509,6 +513,10 @@ class PayTheoryHostedFieldTransactional extends PayTheoryHostedField {
 
   set apiKey(value: string) {
     this._apiKey = value;
+  }
+
+  set checkoutContext(value: CheckoutContextQuery | undefined) {
+    this._checkoutContext = value;
   }
 
   set readyPort(value: MessagePort) {

--- a/src/field-set/handler.ts
+++ b/src/field-set/handler.ts
@@ -70,6 +70,28 @@ export const hostedErrorHandler = (message: {
   error: string;
   field: ElementTypes;
 }) => {
+  const socketErrorCode = (() => {
+    if (typeof message.error !== 'string') return null;
+    const trimmed = message.error.trim();
+
+    // Common case from secure-tags-lib: `SOCKET_ERROR: ERROR_CODE: message`
+    const withoutSocketPrefix = trimmed.startsWith('SOCKET_ERROR:')
+      ? trimmed.slice('SOCKET_ERROR:'.length).trim()
+      : trimmed;
+    const directMatch = withoutSocketPrefix.match(/^([A-Z][A-Z0-9_]+):/);
+    if (directMatch) return directMatch[1];
+
+    // Defensive: tolerate nested/duplicated socket prefixes or other preambles.
+    const nestedMatch = trimmed.match(/(?:^|SOCKET_ERROR:\s*)([A-Z][A-Z0-9_]+):/);
+    return nestedMatch ? nestedMatch[1] : null;
+  })();
+
+  const isSessionInvalid =
+    socketErrorCode === 'SESSION_EXPIRED' ||
+    socketErrorCode === 'SESSION_NOT_FOUND' ||
+    socketErrorCode === 'SESSION_SPENT' ||
+    socketErrorCode === 'CHECKOUT_COMPLETE';
+
   const fieldType = common.isFieldType(message.field);
   if (fieldType) {
     const components = transactingWebComponentMap[fieldType];
@@ -84,12 +106,12 @@ export const hostedErrorHandler = (message: {
           });
         }
 
-        // If the session has expired, set the ready state to false
-        if (message.error.startsWith('SESSION_EXPIRED')) transactingElement.connected = false;
+        // If the session is no longer active, set the ready state to false
+        if (isSessionInvalid) transactingElement.connected = false;
       }
     });
   }
 
   // Do not throw an error if the error is a session expired error
-  if (!message.error.startsWith('SESSION_EXPIRED')) common.handleError(message.error);
+  if (socketErrorCode !== 'SESSION_EXPIRED') common.handleError(message.error);
 };

--- a/src/field-set/payment-fields-v2.ts
+++ b/src/field-set/payment-fields-v2.ts
@@ -12,6 +12,7 @@ import {
 import { processedElement } from '../common/dom';
 import { hostedCheckoutEndpoint } from '../common/network';
 import {
+  CheckoutContextQuery,
   ErrorResponse,
   ErrorType,
   PayTheoryPaymentFieldsInput,
@@ -59,7 +60,8 @@ export const generateUUID = (): string => {
 
 const mountProcessedElements = (props: {
   amount: number | undefined;
-  apiKey: string;
+  apiKey?: string;
+  checkoutContext?: CheckoutContextQuery;
   country: string;
   feeMode: typeof MERCHANT_FEE | typeof SERVICE_FEE | undefined;
   metadata: Record<string | number, string | number | boolean>;
@@ -106,7 +108,8 @@ const mountProcessedElements = (props: {
         });
         typedValue.elements.transacting.forEach(element => {
           const container = document.getElementById(String(element.containerId));
-          element.frame.apiKey = apiKey;
+          if (apiKey) element.frame.apiKey = apiKey;
+          if (props.checkoutContext) element.frame.checkoutContext = props.checkoutContext;
           element.frame.styles = styles;
           element.frame.placeholders = placeholders;
           element.frame.metadata = metadata;
@@ -136,7 +139,6 @@ const initializeFields = (
   port: MessagePort,
 ): ErrorResponse | null => {
   const {
-    apiKey,
     styles = common.defaultStyles,
     metadata = {},
     placeholders = {},
@@ -146,9 +148,12 @@ const initializeFields = (
     amount,
     country = 'USA',
   } = props;
+  const apiKey = 'apiKey' in props ? props.apiKey : undefined;
+  const checkoutContext = 'checkoutContext' in props ? props.checkoutContext : undefined;
   // Validate the input parameters
   const validationError = valid.checkInitialParams(
     apiKey,
+    checkoutContext,
     feeMode,
     metadata,
     styles,
@@ -272,6 +277,7 @@ const initializeFields = (
   return mountProcessedElements({
     amount,
     apiKey,
+    checkoutContext,
     country,
     feeMode,
     metadata,

--- a/src/field-set/validation.ts
+++ b/src/field-set/validation.ts
@@ -54,6 +54,29 @@ const checkApiKey = (key: unknown) => {
   }
 };
 
+const checkCheckoutContext = (checkoutContext: unknown): ErrorResponse | null => {
+  if (!validate<Record<string, unknown>>(checkoutContext, 'object')) {
+    return handleTypedError(
+      ErrorType.INVALID_PARAM,
+      'Checkout context is required and must be an object',
+    );
+  }
+
+  const ctx = checkoutContext as Record<string, unknown>;
+  const provided = ['invoiceId', 'linkId', 'recurringHash', 'sessionId'].filter(
+    key => validate<string>(ctx[key], 'string'),
+  );
+
+  if (provided.length !== 1) {
+    return handleTypedError(
+      ErrorType.INVALID_PARAM,
+      'Must provide exactly one of checkoutContext.invoiceId, checkoutContext.linkId, checkoutContext.recurringHash, or checkoutContext.sessionId',
+    );
+  }
+
+  return null;
+};
+
 const validate = <T>(value: unknown, type: string): value is T => {
   return typeof value === type && Boolean(value);
 };
@@ -113,13 +136,31 @@ const checkCountry = (country: unknown): ErrorResponse | null => {
 
 const checkInitialParams = (
   key: unknown,
+  checkoutContext: unknown,
   mode: unknown,
   metadata: unknown,
   styles: unknown,
   amount: unknown,
   country: unknown,
 ): ErrorResponse | null => {
-  let result = checkApiKey(key);
+  const hasApiKey = validate<string>(key, 'string');
+  const hasCheckoutContext = validate<Record<string, unknown>>(checkoutContext, 'object');
+
+  if (hasApiKey && hasCheckoutContext) {
+    return handleTypedError(
+      ErrorType.INVALID_PARAM,
+      'Provide either apiKey or checkoutContext (not both).',
+    );
+  }
+
+  if (!hasApiKey && !hasCheckoutContext) {
+    return handleTypedError(
+      ErrorType.INVALID_PARAM,
+      'Provide either apiKey or checkoutContext.',
+    );
+  }
+
+  let result = hasCheckoutContext ? checkCheckoutContext(checkoutContext) : checkApiKey(key);
   if (result) return result;
   if (mode) result = checkFeeMode(mode);
   if (result) return result;

--- a/src/messenger/constants.ts
+++ b/src/messenger/constants.ts
@@ -7,6 +7,7 @@ export const PT_MESSENGER_ESTABLISH_CHANNEL = 'pt-messenger:establish_channel' a
 export const PT_MESSENGER_MERCHANT_VALIDATION = 'pt-messenger:merchant_validation' as const;
 export const PT_MESSENGER_WALLET_TRANSACTION = 'pt-messenger:wallet_transaction' as const;
 export const PT_MESSENGER_RECONNECT_TOKEN = 'pt-messenger:reconnect_token' as const;
+export const PT_MESSENGER_RESEND_INVOICE_EMAIL = 'pt-messenger:resend_invoice_email' as const;
 export const PT_MESSENGER_PING = 'pt-messenger:ping' as const;
 
 export type OUTGOING_MESSENGER_TYPES =
@@ -14,6 +15,7 @@ export type OUTGOING_MESSENGER_TYPES =
   | typeof PT_MESSENGER_MERCHANT_VALIDATION
   | typeof PT_MESSENGER_WALLET_TRANSACTION
   | typeof PT_MESSENGER_RECONNECT_TOKEN
+  | typeof PT_MESSENGER_RESEND_INVOICE_EMAIL
   | typeof PT_MESSENGER_PING;
 
 // Incoming messages (Messenger → Parent)
@@ -25,6 +27,8 @@ export const PT_MESSENGER_APPLE_MERCHANT_VALIDATION =
   'pt-messenger:apple_merchant_validation' as const;
 export const PT_MESSENGER_TRANSFER_COMPLETE = 'pt-messenger:transfer_complete' as const;
 export const PT_MESSENGER_RECONNECT_TOKEN_SUCCESS = 'pt-messenger:reconnect_token_success' as const;
+export const PT_MESSENGER_RESEND_INVOICE_EMAIL_SUCCESS =
+  'pt-messenger:resend_invoice_email_success' as const;
 
 // Response types
 export const PT_MERCHANT_VALIDATION = 'merchant_validation' as const;
@@ -36,7 +40,8 @@ export type INCOMING_MESSENGER_TYPES =
   | typeof PT_MESSENGER_READY
   | typeof PT_MESSENGER_APPLE_MERCHANT_VALIDATION
   | typeof PT_MESSENGER_TRANSFER_COMPLETE
-  | typeof PT_MESSENGER_RECONNECT_TOKEN_SUCCESS;
+  | typeof PT_MESSENGER_RECONNECT_TOKEN_SUCCESS
+  | typeof PT_MESSENGER_RESEND_INVOICE_EMAIL_SUCCESS;
 
 // Wallet types
 export const PT_WALLET_TYPE_APPLE = 'APPLE_PAY' as const;

--- a/src/messenger/pay-theory-messenger.ts
+++ b/src/messenger/pay-theory-messenger.ts
@@ -4,6 +4,7 @@ import TokenManager from './token-manager';
 import {
   ApplePaySessionResponse,
   MessengerAppleMerchantValidationMessage,
+  MessengerResendInvoiceEmailSuccessMessage,
   MessengerResponse,
   MessengerSocketErrorMessage,
   MessengerTransferCompleteMessage,
@@ -13,6 +14,7 @@ import {
 } from './types';
 
 import { hostedFieldsEndpoint } from '../common/network';
+import type { CheckoutContextQuery } from '../common/pay_theory_types';
 import { ErrorResponse, ResponseMessageTypes } from '../common/pay_theory_types';
 import { generateUUID } from '../field-set/payment-fields-v2';
 import {
@@ -21,6 +23,8 @@ import {
   PT_MESSENGER_READY,
   PT_MESSENGER_RECONNECT_TOKEN,
   PT_MESSENGER_RECONNECT_TOKEN_SUCCESS,
+  PT_MESSENGER_RESEND_INVOICE_EMAIL,
+  PT_MESSENGER_RESEND_INVOICE_EMAIL_SUCCESS,
   PT_MESSENGER_SOCKET_ERROR,
   PT_MESSENGER_TRANSFER_COMPLETE,
   PT_MESSENGER_WALLET_TRANSACTION,
@@ -36,7 +40,9 @@ import { checkApiKey } from '../field-set/validation';
 class PayTheoryMessenger {
   private static instances: Map<string, PayTheoryMessenger> = new Map();
   private static initializingInstances: Map<string, Promise<MessengerResponse>> = new Map();
-  private apiKey: string;
+  private instanceKey: string;
+  private apiKey: string | null;
+  private checkoutContext: CheckoutContextQuery | null;
   private sessionId?: string;
   private iframe: HTMLIFrameElement | null = null;
   private tokenManager: TokenManager;
@@ -53,26 +59,48 @@ class PayTheoryMessenger {
   static readonly googlePay = PT_WALLET_TYPE_GOOGLE;
   static readonly paze = PT_WALLET_TYPE_PAZE;
 
-  constructor(options: { apiKey: string }) {
+  constructor(
+    options:
+      | { apiKey: string; checkoutContext?: never }
+      | { apiKey?: never; checkoutContext: CheckoutContextQuery },
+  ) {
     // Check if the options is an object and it contains the apiKey property
-    if (typeof options !== 'object' || !options.apiKey) {
+    if (typeof options !== 'object') {
       throw new Error('Invalid options');
     }
 
+    const instanceKey =
+      'apiKey' in options
+        ? options.apiKey
+        : PayTheoryMessenger.createCheckoutContextKey(options.checkoutContext);
+
     // Check if instance already exists for this API key
-    const existingInstance = PayTheoryMessenger.instances.get(options.apiKey);
+    const existingInstance = PayTheoryMessenger.instances.get(instanceKey);
     if (existingInstance) {
       console.warn('PayTheoryMessenger instance already exists for this API key');
       return existingInstance;
     }
 
-    this.apiKey = options.apiKey;
+    this.instanceKey = instanceKey;
+    this.apiKey = 'apiKey' in options ? options.apiKey : null;
+    this.checkoutContext = 'checkoutContext' in options ? options.checkoutContext : null;
     this.sessionId = generateUUID();
-    this.tokenManager = new TokenManager(this.apiKey, this.sessionId);
+    this.tokenManager = new TokenManager(
+      this.apiKey ? { apiKey: this.apiKey } : { checkoutContext: this.checkoutContext! },
+      this.sessionId,
+    );
     this.state = new StateManager();
 
     // Register this instance
-    PayTheoryMessenger.instances.set(options.apiKey, this);
+    PayTheoryMessenger.instances.set(instanceKey, this);
+  }
+
+  private static createCheckoutContextKey(checkoutContext: CheckoutContextQuery): string {
+    if ('invoiceId' in checkoutContext) return `checkoutContext:invoice:${checkoutContext.invoiceId}`;
+    if ('linkId' in checkoutContext) return `checkoutContext:link:${checkoutContext.linkId}`;
+    if ('recurringHash' in checkoutContext)
+      return `checkoutContext:recurring:${checkoutContext.recurringHash}`;
+    return `checkoutContext:session:${checkoutContext.sessionId}`;
   }
 
   // Static method to clear instances (internal use only - for testing)
@@ -87,14 +115,16 @@ class PayTheoryMessenger {
    * Initialize the messenger - create iframe and establish connection
    */
   async initialize(): Promise<MessengerResponse> {
-    const result = checkApiKey(this.apiKey);
-    if (result) {
-      console.error('Invalid API Key', result);
-      return { success: false, error: `${result.type}: ${result.error}` };
+    if (this.apiKey) {
+      const result = checkApiKey(this.apiKey);
+      if (result) {
+        console.error('Invalid API Key', result);
+        return { success: false, error: `${result.type}: ${result.error}` };
+      }
     }
 
     // Check if already initializing globally for this API key
-    const existingInit = PayTheoryMessenger.initializingInstances.get(this.apiKey);
+    const existingInit = PayTheoryMessenger.initializingInstances.get(this.instanceKey);
     if (existingInit) {
       return await existingInit;
     }
@@ -128,14 +158,14 @@ class PayTheoryMessenger {
 
     // Create and store the initialization promise both locally and globally
     this.initializationPromise = this.doInitialize();
-    PayTheoryMessenger.initializingInstances.set(this.apiKey, this.initializationPromise);
+    PayTheoryMessenger.initializingInstances.set(this.instanceKey, this.initializationPromise);
 
     try {
       const result = await this.initializationPromise;
       return result;
     } finally {
       this.initializationPromise = null;
-      PayTheoryMessenger.initializingInstances.delete(this.apiKey);
+      PayTheoryMessenger.initializingInstances.delete(this.instanceKey);
     }
   }
 
@@ -565,6 +595,48 @@ class PayTheoryMessenger {
   }
 
   /**
+   * Resend an invoice email (Security PIN flow for hosted checkout invoices)
+   */
+  async resendInvoiceEmail(): Promise<MessengerResponse> {
+    try {
+      const connectionCheck = await this.ensureConnected();
+      if (!connectionCheck.success) {
+        return connectionCheck;
+      }
+
+      if (!this.channel) {
+        return {
+          success: false,
+          error: 'Channel not initialized',
+        };
+      }
+
+      const response = await this.channel.sendMessage<
+        void,
+        MessengerResendInvoiceEmailSuccessMessage | MessengerSocketErrorMessage
+      >(PT_MESSENGER_RESEND_INVOICE_EMAIL);
+
+      if (response.type === PT_MESSENGER_SOCKET_ERROR) {
+        return {
+          success: false,
+          error: response.body?.error || 'Unknown error',
+        };
+      }
+
+      if (response.type === PT_MESSENGER_RESEND_INVOICE_EMAIL_SUCCESS) {
+        return { success: response.success };
+      }
+
+      return { success: false, error: 'Unexpected response format' };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error resending invoice email',
+      };
+    }
+  }
+
+  /**
    * Process a wallet transaction
    */
   async processWalletTransaction(
@@ -744,7 +816,7 @@ class PayTheoryMessenger {
     this.eventListeners.clear();
 
     // 6. Remove from instances map
-    PayTheoryMessenger.instances.delete(this.apiKey);
+    PayTheoryMessenger.instances.delete(this.instanceKey);
   }
 
   private cleanupEventListeners(): void {

--- a/src/messenger/token-manager.ts
+++ b/src/messenger/token-manager.ts
@@ -1,14 +1,19 @@
-import { fetchPtToken } from '../common/network';
+import { fetchCheckoutPtToken, fetchPtToken } from '../common/network';
+import type { CheckoutContextQuery } from '../common/pay_theory_types';
+
+type TokenManagerAuth =
+  | { apiKey: string; checkoutContext?: never }
+  | { apiKey?: never; checkoutContext: CheckoutContextQuery };
 
 class TokenManager {
-  private apiKey: string;
+  private auth: TokenManagerAuth;
   private sessionId: string;
   private token: string | null = null;
   private tokenExpiry: number = 0;
   private tokenFetchPromise: Promise<string> | null = null;
 
-  constructor(apiKey: string, sessionId: string) {
-    this.apiKey = apiKey;
+  constructor(auth: TokenManagerAuth, sessionId: string) {
+    this.auth = auth;
     this.sessionId = sessionId;
   }
 
@@ -60,7 +65,10 @@ class TokenManager {
    */
   private async fetchTokenFromServer(): Promise<string> {
     try {
-      const result = await fetchPtToken(this.apiKey, this.sessionId);
+      const result =
+        'apiKey' in this.auth
+          ? await fetchPtToken(this.auth.apiKey, this.sessionId)
+          : await fetchCheckoutPtToken(this.auth.checkoutContext, this.sessionId);
 
       if (!result || !result['pt-token']) {
         throw new Error('Token not found in response');

--- a/src/messenger/token-manager.ts
+++ b/src/messenger/token-manager.ts
@@ -39,8 +39,8 @@ class TokenManager {
       const token = await this.tokenFetchPromise;
       this.token = token;
 
-      // Set token expiry to 55 minutes (tokens typically valid for 1 hour)
-      this.tokenExpiry = Date.now() + 55 * 60 * 1000;
+      // Set token expiry based on JWT exp (seconds since epoch)
+      this.tokenExpiry = this.getTokenExpiryMs(token);
 
       return token;
     } finally {
@@ -71,6 +71,29 @@ class TokenManager {
       throw new Error(
         `Token fetch failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
       );
+    }
+  }
+
+  private getTokenExpiryMs(token: string): number {
+    try {
+      const parts = token.split('.');
+      if (parts.length < 2) return Date.now() + 4 * 60 * 1000;
+
+      const payloadB64Url = parts[1];
+      const base64 = payloadB64Url.replace(/-/g, '+').replace(/_/g, '/');
+      const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, '=');
+
+      if (typeof atob !== 'function') return Date.now() + 4 * 60 * 1000;
+      const json = atob(padded);
+
+      const payload = JSON.parse(json) as { exp?: number };
+      const expSeconds = payload.exp;
+      if (!expSeconds || typeof expSeconds !== 'number') return Date.now() + 4 * 60 * 1000;
+
+      // Refresh 10 seconds before expiry to avoid clock skew
+      return expSeconds * 1000 - 10 * 1000;
+    } catch {
+      return Date.now() + 4 * 60 * 1000;
     }
   }
 

--- a/src/messenger/types.ts
+++ b/src/messenger/types.ts
@@ -7,6 +7,8 @@ import {
   PT_MESSENGER_READY,
   PT_MESSENGER_RECONNECT_TOKEN,
   PT_MESSENGER_RECONNECT_TOKEN_SUCCESS,
+  PT_MESSENGER_RESEND_INVOICE_EMAIL,
+  PT_MESSENGER_RESEND_INVOICE_EMAIL_SUCCESS,
   PT_MESSENGER_SOCKET_CONNECTED,
   PT_MESSENGER_SOCKET_ERROR,
   PT_MESSENGER_TRANSFER_COMPLETE,
@@ -99,6 +101,12 @@ export interface MessengerReconnectTokenSuccessMessage {
   success: boolean;
 }
 
+export interface MessengerResendInvoiceEmailSuccessMessage {
+  type: typeof PT_MESSENGER_RESEND_INVOICE_EMAIL_SUCCESS;
+  messageId: string;
+  success: boolean;
+}
+
 export interface MessengerSocketErrorMessage {
   type: typeof PT_MESSENGER_SOCKET_ERROR;
   messageId: string;
@@ -176,6 +184,11 @@ export interface MessengerReconnectTokenMessage {
   data: {
     token: string;
   };
+}
+
+export interface MessengerResendInvoiceEmailMessage {
+  type: typeof PT_MESSENGER_RESEND_INVOICE_EMAIL;
+  messageId: string;
 }
 
 export interface MessengerPingMessage {


### PR DESCRIPTION
> **This PR is part of the [checkout-portal MVP rollout](https://linear.app/pay-theory/issue/PRTL-508/checkout-portal-mvp-rollout-land-checkout-token-migration-across-all) and belongs to the `checkout-token-migration`.**
> Linear parent: **[PRTL-508](https://linear.app/pay-theory/issue/PRTL-508/checkout-portal-mvp-rollout-land-checkout-token-migration-across-all)**

## New architecture

The `checkout-token-migration` replaces AppSync/Apollo in `checkout-portal` with a `GET /checkout-token`
bootstrap from `pt-token-service`, minting a short-lived `pt-token` that carries a labeled
`checkout_context` claim. Hosted fields and the WebSocket complete checkout from that claim alone.

```mermaid
flowchart TD
    CP["checkout-portal<br/>hosted checkout"] -->|"1. GET /checkout-token<br/>no API key in browser"| PTS["pt-token-service"]
    PTS --> DB[("RDS: invoice,<br/>payment_link,<br/>recurring_payment")]
    PTS --> DDB[("DynamoDB:<br/>socket-payment-sessions")]
    PTS -->|"2. checkout, pt-token, origin,<br/>challengeOptions<br/>pt-token carries checkout_context"| CP
    CP -->|"3. init via checkoutContext"| PC["payment-components SDK"]
    PC --> STL["secure-tags-lib<br/>hosted fields"]
    PC -->|"4. WS connect, presents pt-token"| TSS["tags-secure-socket"]
    TSS -->|"5. enforce checkout_context<br/>+ hosted session lifetime"| TSS
    TSS --> SQS[["SQS: PIN resend,<br/>recurring PM update"]]
    RL["rate-limit<br/>Lambda layer"] -.-> TSS
    RL -.-> PTS
```

**Removed by this migration:** AppSync, Apollo, Amplify AppSync usage, and the merchant API secret key from the browser.

## What this repo contributes

The SDK init path that lets the browser drop the merchant API key.

- Adds a `checkoutContext` init mode that fetches `/checkout-token` and uses the returned `pt-token`.
- Aligns socket error parsing so stable `ERROR_CODE` strings survive the `SOCKET_ERROR:` prefix.
- `PayTheoryMessenger` supports `checkoutContext` and exposes `resendInvoiceEmail()`.

`origin/premain` is **3 commits ahead**; this branch is 3 ahead. Merges clean.

## ⚠️ Merging this PR does not ship the SDK

`checkout-portal` has **no npm dependency** on this package — its `package.json` contains neither
`payment-components` nor `secure-tags-lib`. The portal loads the SDK **at runtime from a CDN**
(`https://validate.sdk.paytheorystudy.com/index.js`). There is no version isolation and no lockfile gate:
the portal consumes whatever build is live.

This package carries `"version": "1.3.24-0"` on **both** `origin/premain` and this branch — an
already-published version. So landing this PR alone leaves the portal loading the pre-migration SDK.

**A version bump and publish is required as a separate, deliberate follow-up**, and the dist-tag feeding
`validate.sdk.paytheorystudy.com` still needs to be determined — do not guess it. Tracked as gate 4 on
PRTL-508.

## Review focus

`src/field-set/payment-fields-v2.ts` is the one file shared with `premain`, and it is **proven
non-semantic**: premain adds two lines (an import plus `startComplianceBeacon()` at the top of
`channel.port1.onmessage`), while this branch changes `mountProcessedElements` / `initializeFields` to make
`apiKey` optional and add `checkoutContext`. The regions are disjoint, and nothing under `src/compliance/`
references `apiKey`, `checkoutContext`, or `session` — so making `apiKey` optional cannot affect the beacon.

Called out so nobody re-litigates it. Worth running the suite with attention to `payTheoryFields` init,
since both paths now fire on the same initialization.

---

## Rollout PRs

All PRs in the checkout-portal MVP rollout. Parent: **[PRTL-508](https://linear.app/pay-theory/issue/PRTL-508/checkout-portal-mvp-rollout-land-checkout-token-migration-across-all)**

| Repo | PR | Contribution |
|---|---|---|
| `pt-token-service` | pay-theory/pt-token-service#151 | Mints `/checkout-token` with the `checkout_context` claim |
| `tags-secure-socket` | pay-theory/tags-secure-socket#576 | Enforces `checkout_context` + session lifetime over WebSocket |
| `secure-tags-lib` | pay-theory/secure-tags-lib#514 | Invoice PIN-resend messenger types |
| `payment-components` | **this PR** | `checkoutContext` SDK init (no `apiKey` in browser) |
| `rate-limit` | pay-theory/rate-limit#57 | Limiter DynamoDB TTL + count hardening |
| `checkout-portal` | pay-theory/checkout-portal#99 | Client rollout — already open, needs review |

**Land order:** `rate-limit` (publish layer) → `pt-token-service` ∥ `tags-secure-socket` → `secure-tags-lib` → `payment-components` → `checkout-portal`.

`partner-factory` is out of scope for this rollout — it is an integration manifest rather than a shipping component, is 268 commits behind `premain`, and opening it as-is would land gitlinks pinned to pre-integration commits.

---

## How this PR was opened

Opened **as-is** from `checkout-token-migration` — no premain merge, no rebase, no cherry-picks, per the
rollout decision to make no unnecessary changes to these branches. `premain` was verified to merge cleanly
into this branch on 2026-07-31 via read-only `git merge-tree --write-tree`.

Please land with a **merge commit**, not "Rebase and merge" — these branches are shared.

If GitHub reports `CONFLICTING`, stop: `premain` has moved since the dry-run and the team should re-measure
rather than resolve inline under the rollout deadline.
